### PR TITLE
Replace conformsToProtocol: with respondsToSelector:

### DIFF
--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipNode.h
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipNode.h
@@ -80,11 +80,6 @@ NS_SWIFT_NAME(YapDatabaseRelationshipNode_ObjC)
  * Either side is fine, just pick whichever is easier, or whichever makes more sense for your data model.
  *
  * YapDatabaseRelationship supports one-to-one, one-to-many, and even many-to-many relationships.
- * 
- * Important: This method will not be invoked unless the object implements the protocol.
- * That is, the object's class declaration must have YapDatabaseRelationshipNode in its listed protocols.
- *
- * ... MyObject : NSObject <YapDatabaseRelationshipNode> // <-- Must be in protocol list
  *
  * @see YapDatabaseRelationshipEdge
  */

--- a/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
+++ b/YapDatabase/Extensions/Relationships/YapDatabaseRelationshipTransaction.m
@@ -511,7 +511,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 		
 		NSArray<YapDatabaseRelationshipEdge *> *givenEdges = nil;
 		
-		if ([object conformsToProtocol:@protocol(YapDatabaseRelationshipNode)])
+		if ([object respondsToSelector:@selector(yapDatabaseRelationshipEdges)])
 		{
 			givenEdges = [object yapDatabaseRelationshipEdges];
 		}
@@ -4006,7 +4006,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 	
 	NSArray<YapDatabaseRelationshipEdge *> *givenEdges = nil;
 	
-	if ([object conformsToProtocol:@protocol(YapDatabaseRelationshipNode)])
+	if ([object respondsToSelector:@selector(yapDatabaseRelationshipEdges)])
 	{
 		givenEdges = [object yapDatabaseRelationshipEdges];
 	}
@@ -4076,7 +4076,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 	
 	NSArray<YapDatabaseRelationshipEdge *> *givenEdges = nil;
 	
-	if ([object conformsToProtocol:@protocol(YapDatabaseRelationshipNode)])
+	if ([object respondsToSelector:@selector(yapDatabaseRelationshipEdges)])
 	{
 		givenEdges = [object yapDatabaseRelationshipEdges];
 	}
@@ -4135,7 +4135,7 @@ NS_INLINE BOOL URLMatchesURL(NSURL *url1, NSURL *url2)
 	
 	NSArray<YapDatabaseRelationshipEdge *> *givenEdges = nil;
 	
-	if ([object conformsToProtocol:@protocol(YapDatabaseRelationshipNode)])
+	if ([object respondsToSelector:@selector(yapDatabaseRelationshipEdges)])
 	{
 		givenEdges = [object yapDatabaseRelationshipEdges];
 	}


### PR DESCRIPTION
We've been bitten more than once with a category conforming to a protocol not actually emitting the conformance. The swift code path already uses `respondsToSelector:` and it's easier to get that right so let's go that route.